### PR TITLE
liste_codeurs: sort alphabetically

### DIFF
--- a/resources/public/md/liste_codeurs
+++ b/resources/public/md/liste_codeurs
@@ -1,42 +1,42 @@
 ## Vous voulez témoigner aussi ?  [Forkez](https://github.com/bzg/jecode)-nous !
 
-- [Bastien Guerry](codeurs/bastien.guerry), co-fondateur d'[OLPC France](http://olpc-france.org)
-- [David Roche](codeurs/david.roche)
-- [Martin Quinson](codeurs/martin.quinson), enseignant-chercheur à l'université de Lorraine et développeur [Debian](http://www.debian.org)
+- [Aline Paponaud](codeurs/aline.paponaud), team leader .NET chez Sfeir, Programatoo leader
 - [Antoine Mazières](codeurs/antoine.mazieres)
-- [Fabrice Carrega](codeurs/fabrice.carrega), fondateur d'[Arizuka](http://www.arizuka.com)
-- [Claude Terosier](codeurs/claude.terosier), fondatrice de [magicmakers.fr](http://magicmakers.fr)
-- [Pierre-Nicolas Clauss](codeurs/pierre-nicolas.clauss)
 - [Arnaud Legrand](codeurs/arnaud.legrand), Chercheur au CNRS et père de famille
+- [Audrey Neveu](codeurs/audrey.neveu), Programatoo & Devoxx4Kids France leader, ParisJug Crew Member
+- [Bastien Guerry](codeurs/bastien.guerry), co-fondateur d'[OLPC France](http://olpc-france.org)
+- [Benoît Parsy](codeurs/benoit.parsy), Ingénieur, bidouilleur, animateur d'ateliers de programmation de Lego Mindstorms, membre de [HacKIDemia](http://www.hackidemia.com) 
 - [Brice Goglin](codeurs/brice.goglin), Chercheur à Inria
-- [Fabrice Le Fessant](codeurs/fabrice.le-fessant)
-- [Raphaël Hertzog](codeurs/raphael.hertzog), [consultant](http://www.freexian.com) et développeur [Debian](http://www.debian.org)
-- [Lucas Nussbaum](codeurs/lucas.nussbaum), enseignant-chercheur à l'université de Lorraine et Leader du projet [Debian](http://www.debian.org)
-- [Samuel Thibault](codeurs/samuel.thibault), enseignant-chercheur à l'université de Bordeaux, développeur [Debian](http://www.debian.org)/Accessibilité/Hurd, hackeur réseau
 - [Christophe Sperandio](codeurs/christophe.sperandio), ingénieur supervision système et réseau
+- [Christophe Thomas](codeurs/christophe.thomas)
+- [Claude Terosier](codeurs/claude.terosier), fondatrice de [magicmakers.fr](http://magicmakers.fr)
+- [David Roche](codeurs/david.roche)
+- [Fabrice Carrega](codeurs/fabrice.carrega), fondateur d'[Arizuka](http://www.arizuka.com)
+- [Fabrice Le Fessant](codeurs/fabrice.le-fessant)
+- [Florent Masseglia](codeurs/florent.masseglia), Chercheur Inria
+- [François Tessier](codeurs/francois.tessier)
+- [Georges Vincents](codeurs/georges.vincents)
+- [Guillaume Gonnet](codeurs/guillaume.gonnet)
+- [Jean-Christophe Bach](codeurs/jean-christophe.bach)
+- [Julia Buchner](codeurs/julia.buchner)
+- [Julien Dorra](codeurs/julien.dorra)
+- [Julien Vaubourg](codeurs/julien.vaubourg), Doctorant en informatique et président de <a href="http://ldn-fai.net">Lorraine Data network</a>
+- [Kévin Raymond](codeurs/kevin.raymond), défenseur des logiciels libres, acteur de l'évolution
+- [Lionel Laské](codeurs/lionel.laske)
+- [Luc Didry](codeurs/luc.didry), ingénieur système et réseau à l'université de Lorraine, membre du bureau de [Framasoft](http://www.framasoft.org)
+- [Lucas Nussbaum](codeurs/lucas.nussbaum), enseignant-chercheur à l'université de Lorraine et Leader du projet [Debian](http://www.debian.org)
+- [Ludwine Probst](codeurs/ludwine.probst), Développeuse chez OpenClassrooms, Duchess France Leadeuse
+- [Marion Videau](codeurs/marion.videau), Enseignant-chercheur en informatique et cryptographe
+- [Martin Quinson](codeurs/martin.quinson), enseignant-chercheur à l'université de Lorraine et développeur [Debian](http://www.debian.org)
+- [Maxime Clementz](codeurs/maxime.clementz), Consultant en sécurité & ethical hacker
+- [Pierre-Nicolas Clauss](codeurs/pierre-nicolas.clauss)
+- [Quentin Houbre](codeurs/quentin.houbre)
+- [Raphaël Hertzog](codeurs/raphael.hertzog), [consultant](http://www.freexian.com) et développeur [Debian](http://www.debian.org)
 - [Roberto Di Cosmo](codeurs/roberto.di-cosmo)
 - [Romain Muller](codeurs/romain.muller), Software Development Engineer chez Amazon.
-- [Maxime Clementz](codeurs/maxime.clementz), Consultant en sécurité & ethical hacker
-- [Lionel Laské](codeurs/lionel.laske)
-- [Christophe Thomas](codeurs/christophe.thomas)
-- [François Tessier](codeurs/francois.tessier)
-- [Julien Vaubourg](codeurs/julien.vaubourg), Doctorant en informatique et président de <a href="http://ldn-fai.net">Lorraine Data network</a>
+- [Samuel Thibault](codeurs/samuel.thibault), enseignant-chercheur à l'université de Bordeaux, développeur [Debian](http://www.debian.org)/Accessibilité/Hurd, hackeur réseau
 - [Sebastien Badia](codeurs/sebastien.badia), DevOps et Co-fondateur de <a href='http://ldn-fai.net/'>Lorraine Data Network</a>
-- [Kévin Raymond](codeurs/kevin.raymond), défenseur des logiciels libres, acteur de l'évolution
-- [Julien Dorra](codeurs/julien.dorra)
-- [Aline Paponaud](codeurs/aline.paponaud), team leader .NET chez Sfeir, Programatoo leader
-- [Luc Didry](codeurs/luc.didry), ingénieur système et réseau à l'université de Lorraine, membre du bureau de [Framasoft](http://www.framasoft.org)
-- [Audrey Neveu](codeurs/audrey.neveu), Programatoo & Devoxx4Kids France leader, ParisJug Crew Member
-- [Quentin Houbre](codeurs/quentin.houbre)
-- [Jean-Christophe Bach](codeurs/jean-christophe.bach)
 - [Sebti Mouelhi](codeurs/sebti.mouelhi)
-- [Ludwine Probst](codeurs/ludwine.probst), Développeuse chez OpenClassrooms, Duchess France Leadeuse
-- [Yannick François](codeurs/yannick.francois), Développeur chargé de formation chez Simplon, membre du réseau PocketSensei
-- [Benoît Parsy](codeurs/benoit.parsy), Ingénieur, bidouilleur, animateur d'ateliers de programmation de Lego Mindstorms, membre de [HacKIDemia](http://www.hackidemia.com) 
-- [Georges Vincents](codeurs/georges.vincents)
 - [Situphen](codeurs/situphen)
-- [Florent Masseglia](codeurs/florent.masseglia), Chercheur Inria
-- [Guillaume Gonnet](codeurs/guillaume.gonnet)
-- [Julia Buchner](codeurs/julia.buchner)
 - [Stefano Zacchiroli](codeurs/stefano.zacchiroli), Ancien Leader du Projet Debian, Maître de Conférences en Informatique
-- [Marion Videau](codeurs/marion.videau), Enseignant-chercheur en informatique et cryptographe
+- [Yannick François](codeurs/yannick.francois), Développeur chargé de formation chez Simplon, membre du réseau PocketSensei


### PR DESCRIPTION
Rationale: it is at the point where the list is long enough to look essentially random if sorted by date.
(Alternatively, one can thing of adding _dates_ and preserving the previous ordering, but all in all alphabetically ordering looks the right model for this list.)
